### PR TITLE
Codec check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+##### Converts an FLV file to MP4 file without transcoding.
+##### Since there is no transcoding, FLV codec types must be compatible with MP4. For example an FLV file with H.264 video codec can be converted to MP4 with this program.
+Check `MP4_SUPPORTED_CODECS` and `FLV_SUPPORTED_CODECS` variables for a complete list of supported codecs in [Remuxer.java](https://github.com/kemalyildirim/mediaconverter/blob/main/src/main/java/com/kyildirim/converter/remux/Remuxer.java)

--- a/src/main/java/com/kyildirim/Main.java
+++ b/src/main/java/com/kyildirim/Main.java
@@ -23,6 +23,5 @@ public class Main {
         MediaConverter mCon = new MediaConverter(MediaType.FLV, MediaType.MP4);
         mCon.setIn(in);
         mCon.convert();
-        log.info("{} is converted to mp4 and saved to: {}", in.getAbsolutePath(), mCon.getOut().getAbsolutePath());
     }
 }

--- a/src/main/java/com/kyildirim/converter/MediaConverter.java
+++ b/src/main/java/com/kyildirim/converter/MediaConverter.java
@@ -3,6 +3,7 @@ package com.kyildirim.converter;
 import java.io.File;
 
 import com.kyildirim.converter.remux.Remuxer;
+import com.kyildirim.converter.remux.exception.UnsupportedCodecException;
 import com.kyildirim.types.MediaType;
 
 import lombok.Getter;
@@ -25,7 +26,12 @@ public class MediaConverter {
         inType.checkFileType(in);
         out = new File(createOutputFile("mp4"));
         Remuxer remuxer = new Remuxer(in, out);
-        remuxer.remux();
+        try {
+            remuxer.remux();
+            log.info("{} is converted to mp4 and saved to: {}", in.getAbsolutePath(), out.getAbsolutePath());
+        } catch (UnsupportedCodecException e) {
+            log.error("Remuxing failed.", e);
+        }
     }
 
     private String createOutputFile(String newExtension) {

--- a/src/main/java/com/kyildirim/converter/remux/Remuxer.java
+++ b/src/main/java/com/kyildirim/converter/remux/Remuxer.java
@@ -1,17 +1,20 @@
 package com.kyildirim.converter.remux;
 
+import com.kyildirim.converter.remux.exception.UnsupportedCodecException;
 import org.bytedeco.ffmpeg.avcodec.AVCodecParameters;
 import org.bytedeco.ffmpeg.avcodec.AVPacket;
 import org.bytedeco.ffmpeg.avformat.*;
 import org.bytedeco.ffmpeg.avutil.AVDictionary;
+import org.bytedeco.ffmpeg.global.avcodec;
+import org.bytedeco.ffmpeg.global.avutil;
 import org.bytedeco.javacpp.PointerPointer;
 
-import static org.bytedeco.ffmpeg.global.avcodec.av_packet_unref;
-import static org.bytedeco.ffmpeg.global.avcodec.avcodec_parameters_copy;
+import static org.bytedeco.ffmpeg.global.avcodec.*;
 import static org.bytedeco.ffmpeg.global.avformat.*;
 import static org.bytedeco.ffmpeg.global.avutil.*;
 
 import java.io.File;
+import java.util.Arrays;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -25,6 +28,64 @@ public class Remuxer {
     @Getter
     private File out;
 
+    //src: https://github.com/ant-media/Ant-Media-Server/blob/master/src/main/java/io/antmedia/muxer/Mp4Muxer.java#L77
+    private static int[] MP4_SUPPORTED_CODECS = {
+            AV_CODEC_ID_MOV_TEXT     ,
+            AV_CODEC_ID_MPEG4        ,
+            AV_CODEC_ID_H264         ,
+            AV_CODEC_ID_HEVC         ,
+            AV_CODEC_ID_AAC          ,
+            AV_CODEC_ID_MP4ALS       , /* 14496-3 ALS */
+            AV_CODEC_ID_MPEG2VIDEO  , /* MPEG-2 Main */
+            AV_CODEC_ID_MPEG2VIDEO   , /* MPEG-2 Simple */
+            AV_CODEC_ID_MPEG2VIDEO   , /* MPEG-2 SNR */
+            AV_CODEC_ID_MPEG2VIDEO   , /* MPEG-2 Spatial */
+            AV_CODEC_ID_MPEG2VIDEO   , /* MPEG-2 High */
+            AV_CODEC_ID_MPEG2VIDEO   , /* MPEG-2 422 */
+            AV_CODEC_ID_AAC          , /* MPEG-2 AAC Main */
+            AV_CODEC_ID_MP3          , /* 13818-3 */
+            AV_CODEC_ID_MP2          , /* 11172-3 */
+            AV_CODEC_ID_MPEG1VIDEO   , /* 11172-2 */
+            AV_CODEC_ID_MP3          , /* 11172-3 */
+            AV_CODEC_ID_MJPEG        , /* 10918-1 */
+            AV_CODEC_ID_PNG          ,
+            AV_CODEC_ID_JPEG2000     , /* 15444-1 */
+            AV_CODEC_ID_VC1          ,
+            AV_CODEC_ID_DIRAC        ,
+            AV_CODEC_ID_AC3          ,
+            AV_CODEC_ID_EAC3         ,
+            AV_CODEC_ID_DTS          , /* mp4ra.org */
+            AV_CODEC_ID_VP9          , /* nonstandard, update when there is a standard value */
+            AV_CODEC_ID_TSCC2        , /* nonstandard, camtasia uses it */
+            AV_CODEC_ID_VORBIS       , /* nonstandard, gpac uses it */
+            AV_CODEC_ID_DVD_SUBTITLE , /* nonstandard, see unsupported-embedded-subs-2.mp4 */
+            AV_CODEC_ID_QCELP        ,
+            AV_CODEC_ID_MPEG4SYSTEMS ,
+            AV_CODEC_ID_MPEG4SYSTEMS ,
+            AV_CODEC_ID_NONE
+    };
+
+    // src: https://trac.ffmpeg.org/wiki/SupportedMediaTypesInFormats
+    private static int[] FLV_SUPPORTED_CODECS = {
+            // video
+            AV_CODEC_ID_FLV1,
+            AV_CODEC_ID_H263,
+            AV_CODEC_ID_MPEG4,
+            AV_CODEC_ID_FLASHSV,
+            AV_CODEC_ID_FLASHSV2,
+            AV_CODEC_ID_VP6,
+            AV_CODEC_ID_VP6A,
+            AV_CODEC_ID_H264,
+            // audio
+            AV_CODEC_ID_MP3,
+            AV_CODEC_ID_PCM_U8,
+            AV_CODEC_ID_PCM_S16BE,
+            AV_CODEC_ID_PCM_S16LE,
+            AV_CODEC_ID_ADPCM_SWF,
+            AV_CODEC_ID_AAC,
+            AV_CODEC_ID_NELLYMOSER,
+            AV_CODEC_ID_SPEEX
+    };
     private AVInputFormat inputFormat = new AVInputFormat(null);
     private AVFormatContext inputFormatContext = new AVFormatContext(null);
     private AVFormatContext outputFormatContext = new AVFormatContext(null);
@@ -43,7 +104,7 @@ public class Remuxer {
         av_dict_free(inputDict);
     }
 
-    public void remux() {
+    public void remux() throws UnsupportedCodecException {
         AVOutputFormat outputFormat;
         AVPacket packet = new AVPacket();
         int[] streamMapping;
@@ -69,7 +130,9 @@ public class Remuxer {
             AVStream inStream = inputFormatContext.streams(streamId);
 
             AVCodecParameters inputCodecParams = inStream.codecpar();
-
+            log.trace("Current codec type: {} Current codec name: {}", () -> avutil.av_get_media_type_string(inputCodecParams.codec_type()).getString(),
+                    () -> avcodec.avcodec_get_name(inputCodecParams.codec_id()).getString());
+            checkCodecCompatibility(inputCodecParams);
             // If the current stream is not Audio, Video or Subtitle, mark that streamId with -1.
             if (inputCodecParams.codec_type() != AVMEDIA_TYPE_AUDIO
                     && inputCodecParams.codec_type() != AVMEDIA_TYPE_VIDEO
@@ -140,6 +203,12 @@ public class Remuxer {
         }
 
         avformat_free_context(outputFormatContext);
+    }
+
+    private static void checkCodecCompatibility(AVCodecParameters inputCodecParams) throws UnsupportedCodecException {
+        if (Arrays.stream(MP4_SUPPORTED_CODECS).noneMatch(codecId -> codecId == inputCodecParams.codec_id())) {
+            throw new UnsupportedCodecException("Cannot re-mux the stream with codec " + avcodec.avcodec_get_name(inputCodecParams.codec_id()).getString());
+        }
     }
 
 }

--- a/src/main/java/com/kyildirim/converter/remux/exception/UnsupportedCodecException.java
+++ b/src/main/java/com/kyildirim/converter/remux/exception/UnsupportedCodecException.java
@@ -1,0 +1,10 @@
+package com.kyildirim.converter.remux.exception;
+
+public class UnsupportedCodecException extends Exception {
+    public UnsupportedCodecException(String message) {
+        super(message);
+    }
+    public UnsupportedCodecException(String message, Throwable err) {
+        super(message, err);
+    }
+}


### PR DESCRIPTION
* Introducing UnsupportedCodecException
* Remuxer.remux now throws an exception if the input media's codecs are not compatible with target media container.